### PR TITLE
Broken links

### DIFF
--- a/Mission350Solutions.ipynb
+++ b/Mission350Solutions.ipynb
@@ -24,8 +24,8 @@
     "\n",
     "Collecting data for over four million apps requires a significant amount of time and money, so we'll try to analyze a sample of data instead. To avoid spending resources with collecting new data ourselves, we should first try to see whether we can find any relevant existing data at no cost. Luckily, these are two data sets that seem suitable for our purpose:\n",
     "\n",
-    "- [A data set](https://www.kaggle.com/lava18/google-play-store-apps/home) containing data about approximately ten thousand Android apps from Google Play\n",
-    "- [A data set](https://www.kaggle.com/ramamet4/app-store-apple-data-set-10k-apps/home) containing data about approximately seven thousand iOS apps from the App Store\n",
+    "- [A data set](https://www.kaggle.com/lava18/google-play-store-apps) containing data about approximately ten thousand Android apps from Google Play\n",
+    "- [A data set](https://www.kaggle.com/ramamet4/app-store-apple-data-set-10k-apps) containing data about approximately seven thousand iOS apps from the App Store\n",
     "\n",
     "Let's start by opening the two data sets and then continue with exploring the data."
    ]


### PR DESCRIPTION
Links for data sets are giving 404 error
- Google play store: https://www.kaggle.com/lava18/google-play-store-apps/home
- App store : https://www.kaggle.com/ramamet4/app-store-apple-data-set-10k-apps/home

 they should be
- Google play store: https://www.kaggle.com/lava18/google-play-store-apps
- App store : https://www.kaggle.com/ramamet4/app-store-apple-data-set-10k-apps